### PR TITLE
#9 이미지 리사이즈하여 저장

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -81,7 +81,7 @@ django secret key는 이 사이트에서 생성할 수 있다.
 ```json
 {
     "DJANGO_SECRET_KEY": "장고시크릿키",
-    "DB_PASSWORD": "디비비번"
+    "DB_PASSWORD": "MySQL root계정 비밀번호"
 }
 ```
 

--- a/guide.md
+++ b/guide.md
@@ -4,13 +4,14 @@
 
 GCP, NCP 등등을 통해서 ubuntu 18.04 서버를 만든다. 
 
-서버를 업데이트하고 파이썬과 pip를 다운받는다.
+서버를 업데이트하고 파이썬과 pip 및 파이썬 패키지에 필요한 라이브러리를 다운받는다.
 
 ```bash
 sudo apt update
 
-sudo apt install python-pip
-sudo apt install python3-pip
+sudo apt install python-dev python3-dev
+sudo apt install python-pip python3-pip
+sudo apt install build-essential libssl-dev libffi-dev
 ```
 
 아래 명령어를 통해서 버전을 확인한다.

--- a/guide.md
+++ b/guide.md
@@ -81,7 +81,7 @@ django secret key는 이 사이트에서 생성할 수 있다.
 ```json
 {
     "DJANGO_SECRET_KEY": "장고시크릿키",
-    "DB_PASSWORD": "MySQL root계정 비밀번호"
+    "DB_PASSWORD": "DB비번(MySQL root계정 비밀번호와 같아야함)"
 }
 ```
 
@@ -101,8 +101,6 @@ MySQL을 서버에 설치한다.
 sudo apt install mysql-server
 ```
 
-- 참고: MySQL 설치 후 최초 비밀번호를 요구한다면 아래와 같이 ~/Histudy/pystagram/settings.py에 저장되어 있는 DB 비밀번호와 같이 입력한다.
-
 기본값으로 설정되어 있는 root의 비밀번호를 바꾸기 위해서 mysql을 실행시키고 아래의 명령어를 입력한다.
 
 ```bash
@@ -111,7 +109,8 @@ sudo mysql
 alter user 'root'@'localhost' identified with mysql_native_password by 'password’;
 ```
 
-설정한 password는 ~/Histudy/pystagram/settings.py에 있는 DB 비밀번호에 입력한다.
+설정한 password는 ~/HisSecret/secret.json에 있는 DB 비밀번호와 같아야 한다.
+
 
 MySQL이 한글로 된 데이터를 저장할 수 있도록 `default character set`을 변경해야 한다
 

--- a/photos/models.py
+++ b/photos/models.py
@@ -68,7 +68,6 @@ class Data(models.Model):
     group = models.ForeignKey(Group, on_delete=models.CASCADE, null=True)
     year = models.ForeignKey(Year, on_delete=models.CASCADE, null=True)
     sem = models.IntegerField(null=True)
-    # image = models.ImageField(upload_to='%Y/%m/%d/orig')
     image = ResizedImageField(size=[640, 480], upload_to='%Y/%m/%d/orig', blank=True, null=True)
     title = models.CharField(max_length=100, blank=True, null=True)
     text = models.TextField(null=True, blank=True)

--- a/photos/models.py
+++ b/photos/models.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.core.validators import MaxValueValidator
+from django_resized import ResizedImageField
 
 class Group(models.Model):
     no = models.IntegerField(unique=True)
@@ -67,7 +68,8 @@ class Data(models.Model):
     group = models.ForeignKey(Group, on_delete=models.CASCADE, null=True)
     year = models.ForeignKey(Year, on_delete=models.CASCADE, null=True)
     sem = models.IntegerField(null=True)
-    image = models.ImageField(upload_to='%Y/%m/%d/orig')
+    # image = models.ImageField(upload_to='%Y/%m/%d/orig')
+    image = ResizedImageField(size=[640, 480], upload_to='%Y/%m/%d/orig', blank=True, null=True)
     title = models.CharField(max_length=100, blank=True, null=True)
     text = models.TextField(null=True, blank=True)
     date = models.DateTimeField(default=timezone.now)

--- a/server_requirements.txt
+++ b/server_requirements.txt
@@ -19,6 +19,7 @@ django-js-asset==1.2.2
 django-sslserver==0.22
 django-summernote==0.8.11.6
 django-user-agents==0.4.0
+django-resized==0.3.11
 et-xmlfile==1.0.1
 gunicorn==20.0.4
 hiredis==1.0.1


### PR DESCRIPTION
#9

### 1. 이미지 리사이즈

서버에 업로드되는 사진은 가로 최대 640, 세로 최대 480의 사이즈로 리사이즈되며 비율 자동 조정됨.   

예 (이미지 사이즈는 가로x세로)   
1. 유저가 1280x960 이미지 업로드 --> 640x480 으로 저장   
2. 유저가 1000x1000 이미지 업로드 --> 480x480 으로 저장
3. 유저가 1200x2048 이미지 업로드 --> 281x480 으로 저장
4. 유저가 120x120 이미지 업로드 --> 120x120 으로 저장   

[photos/models.py 의 71 번째 행](https://github.com/dksehdals216/Histudy/pull/10/files#diff-210468456293677cdb1f803c4115f9c3595b637cd6c4bc20c91803ab24885ac9R71) 인자에서 리사이즈 값 조절 가능.   

### 2. 그 외

guide.md 의 모호한 설명 몇 가지 수정.
